### PR TITLE
Remove normalize.css for CssBaseline, add basic sidebar and appbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8786,11 +8786,6 @@
         "sort-keys": "^1.0.0"
       }
     },
-    "normalize.css": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
-      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@material-ui/core": "^4.9.14",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/styles": "^4.9.14",
-    "normalize.css": "^8.0.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/public/index.html
+++ b/public/index.html
@@ -10,8 +10,14 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -1,15 +1,24 @@
 import React from 'react';
 import { Route, Router, Switch } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
+import CssBaseline from '@material-ui/core/CssBaseline';
+
 import PrivateRoute from './PrivateRoute';
+import SideBar from './components/SideBar';
+import AppBar from './components/AppBar';
 
 function AppRouter() {
   return (
-    <Router history={createBrowserHistory()}>
-      <Switch>
-        <Route path="/" component={() => <div></div>} />
-      </Switch>
-    </Router>
+    <>
+      <CssBaseline />
+      <AppBar />
+      <SideBar />
+      <Router history={createBrowserHistory()}>
+        <Switch>
+          <Route path="/" component={() => <div></div>} />
+        </Switch>
+      </Router>
+    </>
   );
 }
 

--- a/src/components/AppBar.jsx
+++ b/src/components/AppBar.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { fade, makeStyles } from '@material-ui/core/styles';
+import { AppBar as MUIAppBar } from '@material-ui/core';
+import { green } from '@material-ui/core/colors';
+import Toolbar from '@material-ui/core/Toolbar';
+import Typography from '@material-ui/core/Typography';
+import TextField from '@material-ui/core/TextField';
+import Link from '@material-ui/core/Link';
+import IconButton from '@material-ui/core/IconButton';
+import Container from '@material-ui/core/Container';
+import EcoIcon from '@material-ui/icons/Eco';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import ChatIcon from '@material-ui/icons/Chat';
+import NotificationsIcon from '@material-ui/icons/Notifications';
+
+const useStyles = makeStyles((theme) => ({
+  appBar: {
+    zIndex: theme.zIndex.drawer + 1
+  },
+  toolBar: {
+    marginLeft: theme.spacing(2),
+    marginRight: theme.spacing(2),
+    display: 'flex',
+    justifyContent: 'space-between'
+  },
+  logo: {
+    display: 'flex'
+  },
+  navigation: {
+    flex: 1
+  },
+  menu: {
+    display: 'flex',
+    alignContent: 'center',
+    justifyContent: 'space-between'
+  },
+  menuItems: {
+    display: 'flex',
+    alignItems: 'center',
+    '& > a:not(:first-child)': {
+      marginLeft: theme.spacing(3)
+    },
+    '& > a': {
+      color: theme.palette.text.secondary,
+      '&:hover': {
+        textDecoration: 'none',
+        color: theme.palette.text.primary
+      }
+    }
+  },
+  search: {
+    position: 'relative',
+    borderRadius: theme.shape.borderRadius,
+    backgroundColor: fade(theme.palette.common.white, 0.15),
+    '&:hover': {
+      backgroundColor: fade(theme.palette.common.white, 0.25)
+    },
+    marginLeft: 0,
+    width: '100%',
+    [theme.breakpoints.up('sm')]: {
+      marginLeft: theme.spacing(1),
+      width: 'auto'
+    }
+  },
+  searchIcon: {
+    padding: theme.spacing(0, 2),
+    height: '100%',
+    position: 'absolute',
+    pointerEvents: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  inputRoot: {
+    color: 'inherit'
+  },
+  inputInput: {
+    padding: theme.spacing(1, 1, 1, 0),
+    // vertical padding + font size from searchIcon
+    paddingLeft: `calc(1em + ${theme.spacing(4)}px)`,
+    transition: theme.transitions.create('width'),
+    width: '100%',
+    [theme.breakpoints.up('sm')]: {
+      width: '12ch',
+      '&:focus': {
+        width: '20ch'
+      }
+    }
+  },
+  account: {}
+}));
+
+export default function AppBar() {
+  const classes = useStyles();
+
+  return (
+    <MUIAppBar
+      position="fixed"
+      className={classes.appBar}
+      color="inherit"
+      variant="outlined"
+    >
+      <Toolbar variant="dense" className={classes.toolBar} disableGutters>
+        <div className={classes.logo}>
+          <EcoIcon style={{ color: green[500] }} fontSize="default" />
+          <Typography variant="h6" noWrap>
+            projectIncubator
+          </Typography>
+        </div>
+        <div className={classes.navigation}>
+          <Container fixed className={classes.menu}>
+            <Typography className={classes.menuItems}>
+              <Link href="#" onClick={(e) => e.preventDefault()}>
+                Dashboard
+              </Link>
+              <Link href="#" onClick={(e) => e.preventDefault()}>
+                Explore
+              </Link>
+              <Link href="#" onClick={(e) => e.preventDefault()}>
+                Search
+              </Link>
+            </Typography>
+            <div className={classes.search}>
+              <TextField
+                id="search-field"
+                placeholder="Search..."
+                variant="outlined"
+                size="small"
+              />
+            </div>
+          </Container>
+        </div>
+        <div className={classes.account}>
+          <IconButton>
+            <ChatIcon />
+          </IconButton>
+          <IconButton>
+            <NotificationsIcon />
+          </IconButton>
+          <IconButton>
+            <AccountCircleIcon />
+          </IconButton>
+        </div>
+      </Toolbar>
+    </MUIAppBar>
+  );
+}

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
+import Drawer from '@material-ui/core/Drawer';
+import List from '@material-ui/core/List';
+import Divider from '@material-ui/core/Divider';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import InboxIcon from '@material-ui/icons/MoveToInbox';
+import MailIcon from '@material-ui/icons/Mail';
+
+const drawerWidth = 58;
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    drawer: {
+      width: drawerWidth,
+      flexShrink: 0
+    },
+    drawerPaper: {
+      width: drawerWidth
+    },
+    // necessary for content to be below app bar
+    toolbar: {
+      // ...theme.mixins.toolbar,
+      minHeight: 48
+    }
+  })
+);
+
+export default function SideBar() {
+  const classes = useStyles();
+
+  return (
+    <Drawer
+      className={classes.drawer}
+      variant="permanent"
+      classes={{
+        paper: classes.drawerPaper
+      }}
+      anchor="left"
+    >
+      <div className={classes.toolbar} />
+      <Divider />
+      <List>
+        {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
+          <ListItem button key={text}>
+            <ListItemIcon>
+              {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+            </ListItemIcon>
+          </ListItem>
+        ))}
+      </List>
+      <Divider />
+      <List>
+        {['All mail', 'Trash', 'Spam'].map((text, index) => (
+          <ListItem button key={text}>
+            <ListItemIcon>
+              {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+            </ListItemIcon>
+          </ListItem>
+        ))}
+      </List>
+    </Drawer>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles';
 import theme from './theme';
 import AppRouter from './AppRouter';
-import 'normalize.css';
 import './index.css';
 
 ReactDOM.render(


### PR DESCRIPTION
Added basic appbar and sidebar. Not currently fully responsive. Removed normalize.css as CssBaseline from Material UI does a similar job. Will need to figure out how to configure the main content configuration (to be discussed later).