### PR TITLE
Add basic routing options, add basic dashboard page

### DIFF
--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -1,21 +1,52 @@
 import React from 'react';
-import { Route, Router, Switch } from 'react-router-dom';
+import {
+  Route,
+  BrowserRouter as Router,
+  Switch,
+  Redirect
+} from 'react-router-dom';
 import { createBrowserHistory } from 'history';
 import CssBaseline from '@material-ui/core/CssBaseline';
-
 import PrivateRoute from './PrivateRoute';
 import SideBar from './components/SideBar';
 import AppBar from './components/AppBar';
+import Dashboard from './pages/Dashboard';
+import Explore from './pages/Explore';
+import Search from './pages/Search';
+
+const NavRoute = ({ exact, path, component: Component }) => (
+  <Route
+    exact={exact}
+    path={path}
+    render={(props) => (
+      <div>
+        <AppBar />
+        <SideBar />
+        <div
+          style={{
+            marginTop: 50,
+            marginLeft: 58,
+            height: 'calc(100vh - 50px)'
+          }}
+        >
+          <Component {...props} />
+        </div>
+      </div>
+    )}
+  />
+);
 
 function AppRouter() {
   return (
     <>
       <CssBaseline />
-      <AppBar />
-      <SideBar />
       <Router history={createBrowserHistory()}>
         <Switch>
-          <Route path="/" component={() => <div></div>} />
+          <NavRoute exact path="/dashboard" component={Dashboard} />
+          <NavRoute exact path="/explore" component={Explore} />
+          <NavRoute exact path="/search" component={Search} />
+          <Route path="/regular" component={() => <div>No Appbar!</div>} />
+          <NavRoute path="/" component={() => <Redirect to="/dashboard" />} />
         </Switch>
       </Router>
     </>

--- a/src/components/AppBar.jsx
+++ b/src/components/AppBar.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { fade, makeStyles } from '@material-ui/core/styles';
+import { NavLink, Link } from 'react-router-dom';
+import { fade, makeStyles, useTheme } from '@material-ui/core/styles';
 import { AppBar as MUIAppBar } from '@material-ui/core';
 import { green } from '@material-ui/core/colors';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
-import Link from '@material-ui/core/Link';
 import IconButton from '@material-ui/core/IconButton';
 import Container from '@material-ui/core/Container';
 import EcoIcon from '@material-ui/icons/Eco';
@@ -26,6 +26,11 @@ const useStyles = makeStyles((theme) => ({
   logo: {
     display: 'flex'
   },
+  logoText: {
+    color: theme.palette.text.primary,
+    textDecoration: 'none',
+    fontWeight: 400
+  },
   navigation: {
     flex: 1
   },
@@ -41,12 +46,16 @@ const useStyles = makeStyles((theme) => ({
       marginLeft: theme.spacing(3)
     },
     '& > a': {
+      textDecoration: 'none',
       color: theme.palette.text.secondary,
       '&:hover': {
         textDecoration: 'none',
         color: theme.palette.text.primary
       }
     }
+  },
+  activeMenu: {
+    color: theme.palette.text.primary
   },
   search: {
     position: 'relative',
@@ -92,6 +101,8 @@ const useStyles = makeStyles((theme) => ({
 
 export default function AppBar() {
   const classes = useStyles();
+  const theme = useTheme();
+  const activeLinkColor = theme.palette.text.primary;
 
   return (
     <MUIAppBar
@@ -104,21 +115,23 @@ export default function AppBar() {
         <div className={classes.logo}>
           <EcoIcon style={{ color: green[500] }} fontSize="default" />
           <Typography variant="h6" noWrap>
-            projectIncubator
+            <Link to="/dashboard" className={classes.logoText}>
+              projectIncubator
+            </Link>
           </Typography>
         </div>
         <div className={classes.navigation}>
           <Container fixed className={classes.menu}>
             <Typography className={classes.menuItems}>
-              <Link href="#" onClick={(e) => e.preventDefault()}>
+              <NavLink to="/dashboard" activeStyle={{ color: activeLinkColor }}>
                 Dashboard
-              </Link>
-              <Link href="#" onClick={(e) => e.preventDefault()}>
+              </NavLink>
+              <NavLink to="/explore" activeStyle={{ color: activeLinkColor }}>
                 Explore
-              </Link>
-              <Link href="#" onClick={(e) => e.preventDefault()}>
+              </NavLink>
+              <NavLink to="/search" activeStyle={{ color: activeLinkColor }}>
                 Search
-              </Link>
+              </NavLink>
             </Typography>
             <div className={classes.search}>
               <TextField

--- a/src/components/FeedItem.jsx
+++ b/src/components/FeedItem.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    flexGrow: 1,
+    display: 'flex',
+    marginBottom: theme.spacing(2)
+  },
+  accountIcon: {
+    paddingRight: theme.spacing(2),
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  content: {
+    flex: 1,
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+    paddingRight: theme.spacing(2),
+    paddingLeft: theme.spacing(2),
+
+    textAlign: 'left',
+    color: theme.palette.text.primary
+  },
+  bold: {
+    fontWeight: 'bold'
+  }
+}));
+
+function FeedItem(props) {
+  const classes = useStyles();
+  return (
+    <div className={classes.root}>
+      <div className={classes.accountIcon}>
+        <AccountCircleIcon fontSize="large" />
+      </div>
+      <Paper variant="outlined" className={classes.content}>
+        <Typography variant="body1" className={classes.header}>
+          <span className={classes.bold}>{props.project + ' '}</span>
+          {props.updateType}:
+        </Typography>
+        {props.content}
+      </Paper>
+    </div>
+  );
+}
+
+export default FeedItem;

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/styles';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import PetsIcon from '@material-ui/icons/Pets';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    marginBottom: theme.spacing(1),
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  icon: {
+    paddingRight: theme.spacing(2),
+    display: 'flex'
+  },
+  projectHeader: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center'
+  },
+  projectName: {
+    lineHeight: 1.2,
+    fontWeight: 400,
+    fontSize: '1.25rem'
+  },
+  projectOwner: {
+    color: theme.palette.text.secondary,
+    fontSize: '0.75rem'
+  },
+  themes: {
+    '& > *': {
+      marginLeft: theme.spacing(1)
+    }
+  }
+}));
+
+function ProjectCard(props) {
+  const classes = useStyles();
+  return (
+    <Paper variant="outlined" className={classes.root}>
+      <div className={classes.icon}>
+        <PetsIcon color="inherit" />
+      </div>
+      <div className={classes.projectHeader}>
+        <Typography variant="h6" className={classes.projectName}>
+          {props.project}
+        </Typography>
+        <Typography variant="body2" className={classes.projectOwner}>
+          Created by {props.owner}
+        </Typography>
+      </div>
+      <div className={classes.themes}>
+        {props.themes.map((theme, index) => (
+          <Button
+            key={props.project + '-' + theme}
+            variant="outlined"
+            color={index % 2 === 0 ? 'primary' : 'secondary'}
+            size="small"
+          >
+            {theme}
+          </Button>
+        ))}
+      </div>
+    </Paper>
+  );
+}
+
+export default ProjectCard;

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -1,32 +1,28 @@
 import React from 'react';
-import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Drawer from '@material-ui/core/Drawer';
 import List from '@material-ui/core/List';
 import Divider from '@material-ui/core/Divider';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
 import InboxIcon from '@material-ui/icons/MoveToInbox';
 import MailIcon from '@material-ui/icons/Mail';
 
 const drawerWidth = 58;
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    drawer: {
-      width: drawerWidth,
-      flexShrink: 0
-    },
-    drawerPaper: {
-      width: drawerWidth
-    },
-    // necessary for content to be below app bar
-    toolbar: {
-      // ...theme.mixins.toolbar,
-      minHeight: 48
-    }
-  })
-);
+const useStyles = makeStyles({
+  drawer: {
+    width: drawerWidth,
+    flexShrink: 0
+  },
+  drawerPaper: {
+    width: drawerWidth
+  },
+  // necessary for content to be below app bar
+  toolbar: {
+    minHeight: 48
+  }
+});
 
 export default function SideBar() {
   const classes = useStyles();

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/styles';
+import Container from '@material-ui/core/Container';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+
+import FeedItem from '../components/FeedItem';
+import ProjectCard from '../components/ProjectCard';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    height: '100%'
+  },
+  content: {
+    borderTop: 'none',
+    height: '100%',
+    padding: theme.spacing(3)
+  },
+  header: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2)
+  }
+}));
+
+function Dashboard() {
+  const classes = useStyles();
+
+  return (
+    <Container className={classes.root} maxWidth="lg" disableGutters>
+      <Paper variant="outlined" className={classes.content} square>
+        <Grid container spacing={2}>
+          <Grid item lg={6} xs={12}>
+            <Typography variant="h5" className={classes.header}>
+              Current Projects
+            </Typography>
+            {[
+              {
+                project: 'Coronavirus Testing BC',
+                owner: 'Alexander Bergholm',
+                themes: ['medicine', 'healthcare', 'politics']
+              },
+              {
+                project: 'Water Pollution BC',
+                owner: 'World Health Organization',
+                themes: ['environmental', 'politics']
+              }
+            ].map((item) => (
+              <ProjectCard
+                key={item.project}
+                project={item.project}
+                owner={item.owner}
+                themes={item.themes}
+              />
+            ))}
+          </Grid>
+          <Grid item lg={6} xs={12}>
+            <Typography variant="h5" className={classes.header}>
+              Followed Projects
+            </Typography>
+            {[
+              {
+                project: 'Coronavirus Testing BC',
+                owner: 'Alexander Bergholm',
+                themes: ['medicine', 'healthcare', 'politics']
+              },
+              {
+                project: 'Water Pollution BC',
+                owner: 'World Health Organization',
+                themes: ['environmental', 'politics']
+              }
+            ].map((item) => (
+              <ProjectCard
+                key={item.project}
+                project={item.project}
+                owner={item.owner}
+                themes={item.themes}
+              />
+            ))}
+          </Grid>
+        </Grid>
+
+        <Typography variant="h5" className={classes.header}>
+          My Feed
+        </Typography>
+
+        {[
+          'Water Pollution BC',
+          'Cakes Are Awesome',
+          'Greenhouse Gasses Begone'
+        ].map((project) => (
+          <FeedItem
+            key={'feed-' + project}
+            project={project}
+            updateType="has a new update"
+            content={
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque sit amet felis at justo luctus tempor. Nam id ligula eu nisl tempor molestie. In tellus.'
+            }
+          />
+        ))}
+      </Paper>
+    </Container>
+  );
+}
+
+export default Dashboard;

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Explore(props) {
+  return <div>Explore page</div>;
+}
+
+export default Explore;

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Search(props) {
+  return <div>Search page</div>;
+}
+
+export default Search;


### PR DESCRIPTION
Added a <NavRoute /> wrapper component to AppRouter that will show the sidebar and appbar. Use the regular <Route /> for non-appbar and non-sidebar pages, such as the login/sign-up pages. 

I also changed the Router import from react-router-dom to BrowserRouter--I'm not entirely sure whether Router was intended for a specific reason, but if so, feel free to comment.

Added a basic dashboard page. Will link the rendered page on Discord for viewing.