### PR TITLE
Add landing page and theme customization, refactor route wrapping

### DIFF
--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  Route,
-  BrowserRouter as Router,
-  Switch,
-  Redirect
-} from 'react-router-dom';
-import { createBrowserHistory } from 'history';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
 import WithBars from './WithBars';
 import Landing from './pages/Landing';
@@ -15,14 +9,14 @@ import Search from './pages/Search';
 
 function AppRouter() {
   return (
-    <Router history={createBrowserHistory()}>
+    <BrowserRouter>
       <Switch>
         <Route exact path="/" component={Landing} />
         <WithBars exact path="/dashboard" component={Dashboard} />
         <WithBars exact path="/explore" component={Explore} />
         <WithBars exact path="/search" component={Search} />
       </Switch>
-    </Router>
+    </BrowserRouter>
   );
 }
 

--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -6,50 +6,23 @@ import {
   Redirect
 } from 'react-router-dom';
 import { createBrowserHistory } from 'history';
-import CssBaseline from '@material-ui/core/CssBaseline';
-import PrivateRoute from './PrivateRoute';
-import SideBar from './components/SideBar';
-import AppBar from './components/AppBar';
+
+import WithBars from './WithBars';
+import Landing from './pages/Landing';
 import Dashboard from './pages/Dashboard';
 import Explore from './pages/Explore';
 import Search from './pages/Search';
 
-const NavRoute = ({ exact, path, component: Component }) => (
-  <Route
-    exact={exact}
-    path={path}
-    render={(props) => (
-      <div>
-        <AppBar />
-        <SideBar />
-        <div
-          style={{
-            marginTop: 50,
-            marginLeft: 58,
-            height: 'calc(100vh - 50px)'
-          }}
-        >
-          <Component {...props} />
-        </div>
-      </div>
-    )}
-  />
-);
-
 function AppRouter() {
   return (
-    <>
-      <CssBaseline />
-      <Router history={createBrowserHistory()}>
-        <Switch>
-          <NavRoute exact path="/dashboard" component={Dashboard} />
-          <NavRoute exact path="/explore" component={Explore} />
-          <NavRoute exact path="/search" component={Search} />
-          <Route path="/regular" component={() => <div>No Appbar!</div>} />
-          <NavRoute path="/" component={() => <Redirect to="/dashboard" />} />
-        </Switch>
-      </Router>
-    </>
+    <Router history={createBrowserHistory()}>
+      <Switch>
+        <Route exact path="/" component={Landing} />
+        <WithBars exact path="/dashboard" component={Dashboard} />
+        <WithBars exact path="/explore" component={Explore} />
+        <WithBars exact path="/search" component={Search} />
+      </Switch>
+    </Router>
   );
 }
 

--- a/src/WithBars.js
+++ b/src/WithBars.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Route } from 'react-router-dom';
+import { withStyles } from '@material-ui/styles';
+import AppBar from './components/AppBar';
+import SideBar from './components/SideBar';
+
+const styles = (theme) => ({
+  root: {
+    padding: `50px 0 0 ${theme.dimensions.drawerWidth}`
+  }
+});
+
+function WithBars({ classes, path, component: Component, ...rest }) {
+  return (
+    <>
+      <AppBar />
+      <SideBar />
+      <div className={classes.root}>
+        <Route
+          path={path}
+          {...rest}
+          render={(props) => <Component {...props} />}
+        />
+      </div>
+    </>
+  );
+}
+
+WithBars.propTypes = {
+  classes: PropTypes.object.isRequired,
+  path: PropTypes.string.isRequired,
+  component: PropTypes.oneOfType([PropTypes.object, PropTypes.func]).isRequired,
+  rest: PropTypes.object
+};
+
+export default withStyles(styles)(WithBars);

--- a/src/components/AppBar.jsx
+++ b/src/components/AppBar.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavLink, Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { fade, makeStyles, useTheme } from '@material-ui/core/styles';
 import { AppBar as MUIAppBar } from '@material-ui/core';
 import Toolbar from '@material-ui/core/Toolbar';

--- a/src/components/AppBar.jsx
+++ b/src/components/AppBar.jsx
@@ -2,16 +2,15 @@ import React from 'react';
 import { NavLink, Link } from 'react-router-dom';
 import { fade, makeStyles, useTheme } from '@material-ui/core/styles';
 import { AppBar as MUIAppBar } from '@material-ui/core';
-import { green } from '@material-ui/core/colors';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
 import IconButton from '@material-ui/core/IconButton';
 import Container from '@material-ui/core/Container';
-import EcoIcon from '@material-ui/icons/Eco';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import ChatIcon from '@material-ui/icons/Chat';
 import NotificationsIcon from '@material-ui/icons/Notifications';
+import Logo from './Logo';
 
 const useStyles = makeStyles((theme) => ({
   appBar: {
@@ -22,14 +21,6 @@ const useStyles = makeStyles((theme) => ({
     marginRight: theme.spacing(2),
     display: 'flex',
     justifyContent: 'space-between'
-  },
-  logo: {
-    display: 'flex'
-  },
-  logoText: {
-    color: theme.palette.text.primary,
-    textDecoration: 'none',
-    fontWeight: 400
   },
   navigation: {
     flex: 1
@@ -112,14 +103,7 @@ export default function AppBar() {
       variant="outlined"
     >
       <Toolbar variant="dense" className={classes.toolBar} disableGutters>
-        <div className={classes.logo}>
-          <EcoIcon style={{ color: green[500] }} fontSize="default" />
-          <Typography variant="h6" noWrap>
-            <Link to="/dashboard" className={classes.logoText}>
-              projectIncubator
-            </Link>
-          </Typography>
-        </div>
+        <Logo />
         <div className={classes.navigation}>
           <Container fixed className={classes.menu}>
             <Typography className={classes.menuItems}>

--- a/src/components/AppBar.jsx
+++ b/src/components/AppBar.jsx
@@ -37,10 +37,8 @@ const useStyles = makeStyles((theme) => ({
       marginLeft: theme.spacing(3)
     },
     '& > a': {
-      textDecoration: 'none',
       color: theme.palette.text.secondary,
       '&:hover': {
-        textDecoration: 'none',
         color: theme.palette.text.primary
       }
     }

--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -13,7 +13,7 @@ const styles = (theme) => ({
   },
   white: {
     '& > *': {
-      color: theme.palette.white
+      color: theme.palette.common.white
     }
   }
 });

--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { withStyles } from '@material-ui/styles';
+import { Typography } from '@material-ui/core';
+import { Eco as EcoIcon } from '@material-ui/icons';
+
+const styles = (theme) => ({
+  primary: {
+    '& > svg': {
+      color: theme.palette.primary.main
+    }
+  },
+  white: {
+    '& > *': {
+      color: theme.palette.white
+    }
+  }
+});
+
+function Logo({ classes, color }) {
+  return (
+    <Link to="/">
+      <div className={classes[color] || classes.primary}>
+        <EcoIcon />
+        <Typography variant="h6" component="span">
+          ProjectIncubator
+        </Typography>
+      </div>
+    </Link>
+  );
+}
+
+Logo.propTypes = {
+  classes: PropTypes.object.isRequired,
+  color: PropTypes.oneOf(['primary', 'white'])
+};
+
+export default withStyles(styles)(Logo);

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -8,21 +8,22 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import InboxIcon from '@material-ui/icons/MoveToInbox';
 import MailIcon from '@material-ui/icons/Mail';
 
-const drawerWidth = 58;
-
-const useStyles = makeStyles({
-  drawer: {
-    width: drawerWidth,
-    flexShrink: 0
-  },
-  drawerPaper: {
-    width: drawerWidth
-  },
-  // necessary for content to be below app bar
-  toolbar: {
-    minHeight: 48
-  }
-});
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    drawer: {
+      width: theme.dimensions.drawerWidth,
+      flexShrink: 0
+    },
+    drawerPaper: {
+      width: theme.dimensions.drawerWidth
+    },
+    // necessary for content to be below app bar
+    toolbar: {
+      // ...theme.mixins.toolbar,
+      minHeight: 48
+    }
+  })
+);
 
 export default function SideBar() {
   const classes = useStyles();

--- a/src/components/SideBar.jsx
+++ b/src/components/SideBar.jsx
@@ -8,22 +8,20 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import InboxIcon from '@material-ui/icons/MoveToInbox';
 import MailIcon from '@material-ui/icons/Mail';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    drawer: {
-      width: theme.dimensions.drawerWidth,
-      flexShrink: 0
-    },
-    drawerPaper: {
-      width: theme.dimensions.drawerWidth
-    },
-    // necessary for content to be below app bar
-    toolbar: {
-      // ...theme.mixins.toolbar,
-      minHeight: 48
-    }
-  })
-);
+const useStyles = makeStyles((theme) => ({
+  drawer: {
+    width: theme.dimensions.drawerWidth,
+    flexShrink: 0
+  },
+  drawerPaper: {
+    width: theme.dimensions.drawerWidth,
+    overflow: 'hidden'
+  },
+  // necessary for content to be below app bar
+  toolbar: {
+    minHeight: 48
+  }
+}));
 
 export default function SideBar() {
   const classes = useStyles();

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,7 @@
-body {
+html,
+body,
+#root {
+  height: 100%;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
@@ -10,4 +13,9 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+a {
+  color: unset;
+  text-decoration: none;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles';
+import {
+  createMuiTheme,
+  MuiThemeProvider,
+  responsiveFontSizes
+} from '@material-ui/core/styles';
+import { CssBaseline } from '@material-ui/core';
 import theme from './theme';
 import AppRouter from './AppRouter';
 import './index.css';
 
 ReactDOM.render(
   <React.StrictMode>
-    <MuiThemeProvider theme={createMuiTheme(theme)}>
+    <MuiThemeProvider theme={responsiveFontSizes(createMuiTheme(theme))}>
+      <CssBaseline />
       <AppRouter />
     </MuiThemeProvider>
   </React.StrictMode>,

--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -2,7 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { withStyles } from '@material-ui/styles';
-import { Container, Typography } from '@material-ui/core';
+import { Button, Container, Grid, Typography } from '@material-ui/core';
+import {
+  Build as BuildIcon,
+  Create as CreateIcon,
+  Forum as ForumIcon
+} from '@material-ui/icons';
 import Logo from '../components/Logo';
 
 const styles = (theme) => ({
@@ -13,22 +18,33 @@ const styles = (theme) => ({
     top: '0',
     left: '0',
     backgroundColor: theme.palette.primary.dark,
+    zIndex: '1000',
     '& > div': {
       height: '100%',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'space-between'
-    },
-    '& a': {
-      color: theme.palette.white,
-      '&:not(:first-of-type)': {
-        margin: theme.spacing(0, 0, 0, 2)
+    }
+  },
+  authBtnContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    '& a, button': {
+      color: theme.palette.common.white,
+      borderColor: theme.palette.common.white,
+      '&:hover': {
+        color: theme.palette.primary.light,
+        borderColor: theme.palette.primary.light,
+        transition: theme.transitions.create()
       }
+    },
+    '& a:not(:first-of-type)': {
+      margin: theme.spacing(0, 0, 0, 2)
     }
   },
   content: {
     padding: '50px 0 0 0',
-    '& > div:nth-of-type(1)': {
+    '& > section:nth-of-type(1)': {
       display: 'flex',
       justifyContent: 'center',
       backgroundColor: theme.palette.primary.main,
@@ -44,15 +60,38 @@ const styles = (theme) => ({
         alignItems: 'center',
         textAlign: 'center',
         '& > p:not(:first-child)': {
-          margin: theme.spacing(2, 0, 0)
+          margin: theme.spacing(2, 0, 4)
         },
-        '& > a': {
-          color: theme.palette.white,
+        '& button': {
+          color: theme.palette.common.white,
           backgroundColor: theme.palette.primary.dark,
-          margin: theme.spacing(4, 0, 0),
-          padding: theme.spacing(2)
+          '&:hover': {
+            opacity: '0.8',
+            transition: theme.transitions.create()
+          }
         }
       }
+    },
+    '& > section:nth-of-type(2) > div > div': {
+      padding: theme.spacing(3, 0, 3),
+      '& > div:not(:first-child)': {
+        [theme.breakpoints.down('sm')]: {
+          paddingTop: theme.spacing(5)
+        }
+      }
+    }
+  },
+  featureContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    flexDirection: 'column',
+    '& > svg': {
+      color: theme.palette.common.white,
+      margin: theme.spacing(0, 0, 2, 0),
+      padding: theme.spacing(3),
+      fontSize: '6rem',
+      borderRadius: '50%',
+      backgroundColor: theme.palette.primary.main
     }
   }
 });
@@ -63,14 +102,16 @@ function Landing({ classes }) {
       <header className={classes.header}>
         <Container maxWidth="lg">
           <Logo color="white" />
-          <div>
+          <div className={classes.authBtnContainer}>
             <Link to="/login">Log In</Link>
-            <Link to="/signup">Sign Up</Link>
+            <Link to="/signup">
+              <Button variant="outlined">Sign Up</Button>
+            </Link>
           </div>
         </Container>
       </header>
       <div className={classes.content}>
-        <div>
+        <section>
           <div>
             <Typography variant="h4" component="p">
               ProjectIncubator
@@ -78,10 +119,44 @@ function Landing({ classes }) {
             <Typography variant="h5" component="p">
               A platform that fosters collaboration on meaningful projects.
             </Typography>
-            <Link to="/dashboard">Get Started</Link>
+            <Link to="/dashboard">
+              <Button color="primary" variant="contained">
+                GET STARTED
+              </Button>
+            </Link>
           </div>
-        </div>
-        <div></div>
+        </section>
+        <section>
+          <Container maxWidth="lg">
+            <Grid container spacing={2}>
+              <Grid item xs={12} md={4}>
+                <div className={classes.featureContainer}>
+                  <BuildIcon />
+                  <Typography component="p">
+                    Handy tools to manage your project.
+                  </Typography>
+                </div>
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <div className={classes.featureContainer}>
+                  <ForumIcon />
+                  <Typography component="p">
+                    Discuss issues with your teammates with our built-in
+                    discussion board.
+                  </Typography>
+                </div>
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <div className={classes.featureContainer}>
+                  <CreateIcon />
+                  <Typography component="p">
+                    Create or join projects you care about.
+                  </Typography>
+                </div>
+              </Grid>
+            </Grid>
+          </Container>
+        </section>
       </div>
       <footer></footer>
     </>

--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { withStyles } from '@material-ui/styles';
+import { Container, Typography } from '@material-ui/core';
+import Logo from '../components/Logo';
+
+const styles = (theme) => ({
+  header: {
+    width: '100%',
+    height: '50px',
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    backgroundColor: theme.palette.primary.dark,
+    '& > div': {
+      height: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between'
+    },
+    '& a': {
+      color: theme.palette.white,
+      '&:not(:first-of-type)': {
+        margin: theme.spacing(0, 0, 0, 2)
+      }
+    }
+  },
+  content: {
+    padding: '50px 0 0 0',
+    '& > div:nth-of-type(1)': {
+      display: 'flex',
+      justifyContent: 'center',
+      backgroundColor: theme.palette.primary.main,
+      [theme.breakpoints.down('sm')]: {
+        padding: theme.spacing(6, 0, 8)
+      },
+      [theme.breakpoints.up('md')]: {
+        padding: theme.spacing(8, 0, 10)
+      },
+      '& > div': {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        textAlign: 'center',
+        '& > p:not(:first-child)': {
+          margin: theme.spacing(2, 0, 0)
+        },
+        '& > a': {
+          color: theme.palette.white,
+          backgroundColor: theme.palette.primary.dark,
+          margin: theme.spacing(4, 0, 0),
+          padding: theme.spacing(2)
+        }
+      }
+    }
+  }
+});
+
+function Landing({ classes }) {
+  return (
+    <>
+      <header className={classes.header}>
+        <Container maxWidth="lg">
+          <Logo color="white" />
+          <div>
+            <Link to="/login">Log In</Link>
+            <Link to="/signup">Sign Up</Link>
+          </div>
+        </Container>
+      </header>
+      <div className={classes.content}>
+        <div>
+          <div>
+            <Typography variant="h4" component="p">
+              ProjectIncubator
+            </Typography>
+            <Typography variant="h5" component="p">
+              A platform that fosters collaboration on meaningful projects.
+            </Typography>
+            <Link to="/dashboard">Get Started</Link>
+          </div>
+        </div>
+        <div></div>
+      </div>
+      <footer></footer>
+    </>
+  );
+}
+
+Landing.propTypes = {
+  classes: PropTypes.object.isRequired
+};
+
+export default withStyles(styles)(Landing);

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,3 +1,13 @@
+import { green } from '@material-ui/core/colors';
+
 export default {
-  palette: {}
+  palette: {
+    primary: {
+      main: green['400']
+    },
+    white: '#ffffff'
+  },
+  dimensions: {
+    drawerWidth: '58px'
+  }
 };

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -4,8 +4,17 @@ export default {
   palette: {
     primary: {
       main: green['400']
-    },
-    white: '#ffffff'
+    }
+  },
+  props: {
+    MuiButton: {
+      disableElevation: true
+    }
+  },
+  typography: {
+    button: {
+      textTransform: 'none'
+    }
   },
   dimensions: {
     drawerWidth: '58px'


### PR DESCRIPTION
- added landing page
- removed `NavRoute` and added `WithBars`, which is basically the same thing but with bars rendering on the outside of `Route` (I think we can get rid of PrivateRoute in the future as well and probably move auth check functionality into `WithBars`)
- added `Logo` component
- added global css rules for anchors
- added some configurations to the theme and the primary color